### PR TITLE
fix crash in pcm-latency when run as a non-root

### DIFF
--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -3110,7 +3110,7 @@ void PCM::cleanupUncorePMUs()
 
 void PCM::resetPMU()
 {
-    for (int i = 0; i < (int)num_cores; ++i)
+    for (int i = 0; i < (int)MSR.size(); ++i)
     {
         // disable all counters
         MSR[i]->write(IA32_CR_PERF_GLOBAL_CTRL, 0);


### PR DESCRIPTION
addresses issue reposted in https://github.com/opcm/pcm/issues/187

Change-Id: Iace49a011eab0710f8ecc492eb11eeb1341df40c